### PR TITLE
Fix: Fixing errors caused by current and navigate

### DIFF
--- a/src/assets/icon/couponGage.svg
+++ b/src/assets/icon/couponGage.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="current" height="current" viewBox="0 0 181 17" fill="none">
-  <rect x="0.0869141" y="0.736328" width="current" height="current" rx="8" fill="#EFEFEF"/>
+  <rect x="0.0869141" y="0.736328"  rx="8" fill="#EFEFEF"/>
   <path d="M0.0869141 8.73633C0.0869141 4.31805 3.66864 0.736328 8.08691 0.736328H121.147V16.7363H8.08692C3.66864 16.7363 0.0869141 13.1546 0.0869141 8.73633Z" fill="#C9CEFF"/>
 </svg>

--- a/src/pages/Mission/Today/MissionToday.tsx
+++ b/src/pages/Mission/Today/MissionToday.tsx
@@ -23,7 +23,7 @@ const MissionToday = () => {
           backBtnColor="white"
           headerTitle="미션"
           headerTitleColor="white"
-          onClickBackBtn={() => navigate(-1)}
+          onClickBackBtn={() => navigate('/')}
         />
       </div>
       <div className={styles.wrapUserInformation}>
@@ -71,7 +71,7 @@ const MissionToday = () => {
               다음 스탬프 획득까지 미션 {MissionCntData[0].todayMissionCnt}개
               남았습니다.
             </div>
-            <CoupongageImage />
+            <CoupongageImage width={180} height={16} />
           </div>
           <TodayMission title={MissionTitleData[0].title} />
           <TodayMission title={MissionTitleData[1].title} />


### PR DESCRIPTION
1. 미션에 들어가면 console 창에 뜨는 에러를 수정했습니다.
- current로 지정해놓고 값을 부여하지 않으면 생기는 에러로, 
무의미한 width, height를 svg에서 지우거나 tsx에서 width, height 값을 number로 부여했습니다.

2. MissionToday.tsx에서 navigate(-1) -> navigate('/')로 수정했습니다.
- navigate(-1)로 하면 뒤로가기 버튼을 눌렀을 때 MissionMap.tsx로 넘어가는 에러가 발생했기 때문입니다.